### PR TITLE
Lax faraday version constraint (to minor version)

### DIFF
--- a/scaleapi-ruby.gemspec
+++ b/scaleapi-ruby.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.5"
   spec.add_development_dependency "vcr", "~> 4.0"
 
-  spec.add_dependency "faraday", "~> 0.11.0"
+  spec.add_dependency "faraday", "~> 0.11"
 end


### PR DESCRIPTION
Faraday v0.12.0 was released over [two years ago](https://github.com/lostisland/faraday/releases/tag/v0.12.0). Rather than guard against future minor versions, for this particular case, I'd suggest relaxing the constraint, >= 0.11 and < 1.0.